### PR TITLE
Minor extension/fixups so it works (for me) on the provided sample file

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -7,7 +7,6 @@
     "contrasts": {
       "ttest": {
         "type": "object",
-        "required": [],
         "properties": {
           "name": {
             "type": "string"
@@ -32,7 +31,6 @@
       },
       "Ftest": {
         "type": "object",
-        "required": [],
         "properties": {
           "name": {
             "type": "string"
@@ -419,7 +417,6 @@
     }
   },
   "type": "object",
-  "required": [],
   "additionalProperties": false,
   "properties": {
     "name": {
@@ -430,7 +427,6 @@
     },
     "input": {
       "type": "object",
-      "required": [],
       "properties": {
         "task": {
           "type": "string"
@@ -441,7 +437,6 @@
       "type": "array",
       "items": {
         "type": "object",
-        "required": [],
         "additionalProperties": false,
         "properties": {
           "level": {
@@ -477,7 +472,6 @@
           "model": {
             "type": "object",
             "additionalProperties": false,
-            "required": [],
             "properties": {
               "model_type": {"type": "string"},
               "variables": {

--- a/schema.json
+++ b/schema.json
@@ -1,4 +1,8 @@
 {
+  "title": "BIDS Stats-Models Specification (BEP002) Schema",
+  "description": "BIDS Stats-Models Specification (BEP002) is still under active development, so schema is not yet finalized",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
   "definitions": {
     "contrasts": {
       "ttest": {


### PR DESCRIPTION
Before:
```shell
$> jsonschema -i ds000001_model.json schema.json
Traceback (most recent call last):
  File "/usr/bin/jsonschema", line 11, in <module>
    load_entry_point('jsonschema==2.6.0', 'console_scripts', 'jsonschema')()
  File "/usr/lib/python2.7/dist-packages/jsonschema/cli.py", line 67, in main
    sys.exit(run(arguments=parse_args(args=args)))
  File "/usr/lib/python2.7/dist-packages/jsonschema/cli.py", line 74, in run
    validator.check_schema(arguments["schema"])
  File "/usr/lib/python2.7/dist-packages/jsonschema/validators.py", line 83, in check_schema
    raise SchemaError.create_from(error)
jsonschema.exceptions.SchemaError: [] is too short

Failed validating u'minItems' in schema[u'properties'][u'properties'][u'additionalProperties'][u'properties'][u'required']:
    {u'items': {u'type': u'string'},
     u'minItems': 1,
     u'type': u'array',
     u'uniqueItems': True}

On instance[u'properties'][u'input'][u'required']:
    []
```
after:
```shell
$> jsonschema -i ds000001_model.json schema.json  
$> echo $?
0
```
although probably header was not really needed, added it anyways ;-)